### PR TITLE
Fix web converter in Chrome

### DIFF
--- a/converter_web.py
+++ b/converter_web.py
@@ -12,7 +12,7 @@ class WebConverter:
         [file] = evt.target.files
         print(f"{file.name}: {file.size} bytes")
 
-        rom_data = (await file.bytes()).to_bytes()
+        rom_data = (await file.arrayBuffer()).to_bytes()
         try: 
             self.rom = convert.INes(rom_data)
             stem, _, _ = file.name.partition(".")


### PR DESCRIPTION
Blob.bytes is only supported by Safari and Firefox, according to
https://caniuse.com/mdn-api_blob_bytes. Use Blob.arrayBuffer instead,
so everything works in Chromium-based browsers.